### PR TITLE
Deathwatch Ark of Omens Points Update

### DIFF
--- a/Imperium - Deathwatch.cat
+++ b/Imperium - Deathwatch.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="203b-f8dd-2a64-2676" name="Imperium - Adeptus Astartes - Deathwatch" revision="170" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Technoblazed @FarseerV" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="232" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="203b-f8dd-2a64-2676" name="Imperium - Adeptus Astartes - Deathwatch" revision="170" battleScribeVersion="2.03" authorName="BSData Developers" authorContact="@Technoblazed @FarseerV" authorUrl="https://www.bsdata.net/contact" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="235" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="1973-efc9-3214-865a" name="Codex: Space Marines"/>
     <publication id="b8dc-efc0-c6b3-2c9f" name="Codex Supplement: Deathwatch" publisher="Codex Supplement: Deathwatch" publicationDate="2020-11-07" publisherUrl="https://www.games-workshop.com/en-GB/Codex-Supplement-Deathwatch-EN-2020"/>
@@ -2509,7 +2509,7 @@
         <entryLink id="bef9-03c9-39fc-1542" name="Stratagems" hidden="false" collective="false" import="true" targetId="dbd7-664a-a559-6781" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130.0"/>
+        <cost name="pts" typeId="points" value="115.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -2610,7 +2610,7 @@
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
-        <cost name="pts" typeId="points" value="100.0"/>
+        <cost name="pts" typeId="points" value="90.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -2715,7 +2715,7 @@
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
-        <cost name="pts" typeId="points" value="105.0"/>
+        <cost name="pts" typeId="points" value="95.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -2804,7 +2804,7 @@
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
-        <cost name="pts" typeId="points" value="95.0"/>
+        <cost name="pts" typeId="points" value="85.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -2816,7 +2816,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2017-2709-a4ed-77bf" name="Deathwatch Combi-flamer" page="" hidden="false" collective="false" import="true" type="upgrade">
@@ -2829,7 +2829,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="10.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c94b-3c50-8214-c7cc" name="Deathwatch Combi-grav" page="62" hidden="false" collective="false" import="true" type="upgrade">
@@ -2842,7 +2842,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="15.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2f4f-a8b2-8b30-3841" name="Deathwatch Combi-melta" page="" hidden="false" collective="false" import="true" type="upgrade">
@@ -2855,7 +2855,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="15.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7006-cb24-2df9-fce0" name="Deathwatch Combi-plasma" page="" hidden="false" collective="false" import="true" type="upgrade">
@@ -2869,7 +2869,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="15.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f9f4-e6be-37ab-c7bf" name="Corvus Blackstar" page="" hidden="false" collective="false" import="true" type="model">
@@ -2980,7 +2980,7 @@
                 <infoLink id="8791-3963-945e-a421" name="Auspex array" hidden="false" targetId="6b53-fe7d-9bb0-776f" type="profile"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
@@ -2990,7 +2990,7 @@
                 <infoLink id="1a05-3cf6-40df-79dd" name="Infernum halo-launcher" hidden="false" targetId="5ba5-54ce-c3d0-83dd" type="profile"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
@@ -3004,13 +3004,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c3f-c3b2-4f07-6356" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
-        <cost name="pts" typeId="points" value="165.0"/>
+        <cost name="pts" typeId="points" value="150.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -3081,17 +3081,17 @@
             <entryLink id="3d2a-1e3b-4088-a85e" name="Astartes Chainsword" hidden="false" collective="false" import="true" targetId="c5f0-76db-2a6c-403e" type="selectionEntry"/>
             <entryLink id="811b-cc8c-5c81-6dde" name="Power axe" hidden="false" collective="false" import="true" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="3.0"/>
+                <modifier type="set" field="points" value="0.0"/>
               </modifiers>
             </entryLink>
             <entryLink id="41e2-b22c-36fc-0625" name="Power maul" hidden="false" collective="false" import="true" targetId="6ea7-1195-7144-438e" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="3.0"/>
+                <modifier type="set" field="points" value="0.0"/>
               </modifiers>
             </entryLink>
             <entryLink id="b5a0-2a29-ff36-fb63" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="3.0"/>
+                <modifier type="set" field="points" value="0.0"/>
               </modifiers>
             </entryLink>
           </entryLinks>
@@ -3114,7 +3114,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="30.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cd36-3269-a409-dc13" name="Veteran Bike Squad" page="" hidden="false" collective="false" import="true" type="unit">
@@ -3174,7 +3174,7 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="30.0"/>
+                <cost name="pts" typeId="points" value="35.0"/>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
@@ -3196,12 +3196,12 @@
                   <entryLinks>
                     <entryLink id="da16-3617-d4f8-3b3d" name="Heavy bolter" hidden="false" collective="false" import="true" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
                       <costs>
-                        <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name="pts" typeId="points" value="0.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="bccf-f776-cb4c-732c" name="Multi-melta" hidden="false" collective="false" import="true" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
                       <costs>
-                        <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name="pts" typeId="points" value="0.0"/>
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -3228,7 +3228,7 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="30.0"/>
+                <cost name="pts" typeId="points" value="35.0"/>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
@@ -3240,6 +3240,9 @@
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1773-1cfe-6104-705f" type="min"/>
                 <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9e4-4d87-ea8e-644f" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="35.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -3247,7 +3250,6 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1657-11b4-c657-c91e" name="Deathwatch Shotgun" page="" hidden="false" collective="false" import="true" type="upgrade">
@@ -3259,7 +3261,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fcfd-2bdb-cb53-7dc8" name="Stalker-pattern boltgun" page="" hidden="false" collective="false" import="true" type="upgrade">
@@ -3325,7 +3327,7 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="33.0"/>
+                <cost name="pts" typeId="points" value="35.0"/>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
@@ -3373,7 +3375,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="33.0"/>
+        <cost name="pts" typeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1364-9aeb-1643-a270" name="Deathwatch Terminator w/ Heavy Weapon" hidden="false" collective="false" import="true" type="model">
@@ -3408,7 +3410,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="33.0"/>
+        <cost name="pts" typeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cf95-e99b-f54b-f6e8" name="Deathwatch Teleport Homer" page="" hidden="false" collective="false" import="true" type="upgrade">
@@ -3416,7 +3418,7 @@
         <infoLink id="d2e1-1c49-786a-5058" name="Deathwatch teleport homer" hidden="false" targetId="8e59-0e9b-eb4b-620b" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -3714,7 +3716,7 @@
           <entryLinks>
             <entryLink id="ec8a-44bd-bf59-3d11" name="Lightning Claw (Pair)" hidden="false" collective="false" import="true" targetId="b050-572b-911b-d51c" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="0.0"/>
+                <modifier type="set" field="points" value="6.0"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbc0-7f27-aea8-7e7f" type="min"/>
@@ -3786,7 +3788,7 @@
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="13.0"/>
-        <cost name="pts" typeId="points" value="240.0"/>
+        <cost name="pts" typeId="points" value="220.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -3822,7 +3824,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d1e3-cb9b-c22b-e720" name="Deathwatch Veteran" hidden="false" collective="false" import="true" type="model">
@@ -3864,7 +3866,7 @@
                 </entryLink>
                 <entryLink id="9ce8-b584-698f-56e3" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="3.0"/>
+                    <modifier type="set" field="points" value="0.0"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d17b-156d-3862-c2aa" type="max"/>
@@ -3899,7 +3901,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="27.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="327d-4ca1-5b95-ca88" name="Deathwatch Veterans" hidden="false" collective="false" import="true" type="unit">
@@ -3975,14 +3977,14 @@
                         </entryLink>
                         <entryLink id="9b44-d578-4d58-6e75" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
                           <modifiers>
-                            <modifier type="set" field="points" value="3.0"/>
+                            <modifier type="set" field="points" value="0.0"/>
                           </modifiers>
                           <constraints>
                             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0929-f8a5-35ab-2677" type="max"/>
                             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8974-9dfb-48aa-a319" type="min"/>
                           </constraints>
                           <costs>
-                            <cost name="pts" typeId="points" value="3.0"/>
+                            <cost name="pts" typeId="points" value="0.0"/>
                           </costs>
                         </entryLink>
                       </entryLinks>
@@ -4033,7 +4035,7 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6cc-d3ca-1199-41c2" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name="pts" typeId="points" value="12.0"/>
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -4101,7 +4103,7 @@
                         </entryLink>
                         <entryLink id="b60e-8bb0-b204-a15f" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
                           <modifiers>
-                            <modifier type="set" field="points" value="3.0"/>
+                            <modifier type="set" field="points" value="0.0"/>
                           </modifiers>
                           <constraints>
                             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ed0-5bce-351d-960c" type="max"/>
@@ -4146,7 +4148,7 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05b6-19c6-6988-555f" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name="pts" typeId="points" value="12.0"/>
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -4174,7 +4176,7 @@
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="20.0"/>
+                <cost name="pts" typeId="points" value="27.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4705,7 +4707,7 @@
               <entryLinks>
                 <entryLink id="d729-d377-94ff-2c0c" name="Incursor" hidden="false" collective="false" import="true" targetId="55fb-72d1-1ffa-ffbe" type="selectionEntry">
                   <costs>
-                    <cost name="pts" typeId="points" value="21.0"/>
+                    <cost name="pts" typeId="points" value="18.0"/>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>
                   </costs>
                 </entryLink>
@@ -4717,7 +4719,7 @@
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8366-7570-601a-0117" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="21.0"/>
+                    <cost name="pts" typeId="points" value="18.0"/>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>
                   </costs>
                 </entryLink>
@@ -4727,13 +4729,13 @@
               <entryLinks>
                 <entryLink id="b376-337f-f618-3488" name="Reiver w/ Bolt carbine" hidden="false" collective="false" import="true" targetId="6278-f9d3-6966-5972" type="selectionEntry">
                   <costs>
-                    <cost name="pts" typeId="points" value="18.0"/>
+                    <cost name="pts" typeId="points" value="16.0"/>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>
                   </costs>
                 </entryLink>
                 <entryLink id="d71c-ae20-8935-4faf" name="Reiver w/ Combat blade" hidden="false" collective="false" import="true" targetId="d1c5-fff9-aa7c-b7c9" type="selectionEntry">
                   <costs>
-                    <cost name="pts" typeId="points" value="18.0"/>
+                    <cost name="pts" typeId="points" value="16.0"/>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>
                   </costs>
                 </entryLink>
@@ -4835,7 +4837,7 @@
             </entryLink>
             <entryLink id="63fb-4670-83df-05a5" name="Reiver grav chute" hidden="false" collective="false" import="true" targetId="0093-b98e-176b-b326" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="points" value="1.0">
+                <modifier type="increment" field="points" value="0.0">
                   <repeats>
                     <repeat field="selections" scope="0a19-890d-f924-0f87" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d1c5-fff9-aa7c-b7c9" repeats="1" roundUp="false"/>
                     <repeat field="selections" scope="0a19-890d-f924-0f87" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6278-f9d3-6966-5972" repeats="1" roundUp="false"/>
@@ -4901,7 +4903,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="45.0"/>
+        <cost name="pts" typeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="934e-4096-2dde-e9eb" name="Assault Plasma Incinerator" hidden="false" collective="true" import="true" type="upgrade">
@@ -4962,7 +4964,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="33.0"/>
+        <cost name="pts" typeId="points" value="30.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -4992,7 +4994,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="33.0"/>
+        <cost name="pts" typeId="points" value="30.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5022,7 +5024,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="33.0"/>
+        <cost name="pts" typeId="points" value="30.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5057,7 +5059,7 @@
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -5113,7 +5115,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="29.0"/>
+        <cost name="pts" typeId="points" value="20.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5143,7 +5145,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61ad-5478-7d6a-b6b4" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
             <entryLink id="d003-3e46-22ab-210c" name="Thunder hammer" hidden="false" collective="false" import="true" targetId="f1cb-bfc4-0b93-1203" type="selectionEntry">
@@ -5151,7 +5153,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e9f-2e1d-28b8-f10b" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -5225,7 +5227,7 @@
                 <constraint field="selections" scope="0a63-b444-523a-72a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9060-3d0b-63c2-33ea" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -5252,7 +5254,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="18.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5282,7 +5284,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="18.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5312,7 +5314,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="18.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5342,7 +5344,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="18.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5395,12 +5397,12 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a52-3a00-f1a1-bd6f" type="min"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="18.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5452,7 +5454,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="24.0"/>
+        <cost name="pts" typeId="points" value="20.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a28a-50a8-e5aa-470d" name="Auto Boltstorm Gauntlets" hidden="false" collective="true" import="true" type="upgrade">
@@ -5497,7 +5499,7 @@
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" typeId="points" value="40.0"/>
+        <cost name="pts" typeId="points" value="30.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -5508,7 +5510,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6ae6-0ceb-b567-2aa0" name="Aggressor w/ Flamestorm Gauntlets" hidden="false" collective="false" import="true" type="model">
@@ -5525,7 +5527,7 @@
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" typeId="points" value="40.0"/>
+        <cost name="pts" typeId="points" value="30.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -5583,7 +5585,7 @@
           <selectionEntryGroups>
             <selectionEntryGroup id="626b-7e60-6e1f-aba7" name="Aggressors" hidden="false" collective="false" import="true">
               <entryLinks>
-                <entryLink id="72ce-4256-16d9-57aa" name="Aggressor" hidden="false" collective="false" import="true" targetId="4bb1-b164-f21a-d8ab" type="selectionEntry">
+                <entryLink id="72ce-4256-16d9-57aa" name="Aggressor w/ Boltstorm Gauntlets/Fragstorm Launcher" hidden="false" collective="false" import="true" targetId="4bb1-b164-f21a-d8ab" type="selectionEntry">
                   <costs>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
                   </costs>
@@ -5757,7 +5759,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="28.0"/>
+        <cost name="pts" typeId="points" value="23.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5797,7 +5799,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="28.0"/>
+        <cost name="pts" typeId="points" value="23.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5827,7 +5829,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="28.0"/>
+        <cost name="pts" typeId="points" value="23.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5868,7 +5870,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f721-d397-3e40-8cd3" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
             <entryLink id="7e31-c317-514e-b8ba" name="Hellstorm Heavy Bolter" hidden="false" collective="false" import="true" targetId="bc53-a90c-189a-1a3c" type="selectionEntry">
@@ -5899,7 +5901,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="28.0"/>
+        <cost name="pts" typeId="points" value="23.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5909,7 +5911,7 @@
         <infoLink id="707a-c8ef-6c24-5b95" name="Executor heavy bolter" hidden="false" targetId="65d6-071a-0a86-141c" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="10.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5919,7 +5921,7 @@
         <infoLink id="76c0-63d3-0f79-726f" name="Hellstorm heavy bolter" hidden="false" targetId="a9ca-b897-7b4a-c2e6" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="10.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -5974,7 +5976,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="28.0"/>
+        <cost name="pts" typeId="points" value="23.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -6013,7 +6015,7 @@
         <infoLink id="f6b4-0875-b179-8764" name="Plasma Exterminator, Supercharged" hidden="false" targetId="c1e5-688f-13e6-ac26" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="10.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -6031,7 +6033,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="50.0"/>
+        <cost name="pts" typeId="points" value="40.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -6091,7 +6093,7 @@
       <entryLinks>
         <entryLink id="c887-a411-8a01-5ff4" name="Multi-melta" hidden="false" collective="false" import="true" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="10.0"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f28-374d-4e6b-69c8" type="max"/>
@@ -6116,7 +6118,7 @@
         <infoLink id="9074-84ff-be1a-cca4" name="Heavy melta rifle" hidden="false" targetId="53ac-7aac-447c-a2f1" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="5.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -6132,7 +6134,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d088-23c6-6e55-2f00" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
+            <cost name="pts" typeId="points" value="12.0"/>
           </costs>
         </entryLink>
         <entryLink id="c403-c120-4a2d-7128" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
@@ -6145,7 +6147,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="27.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3f89-cfd9-229c-38ce" name="Deathwatch Veteran w/ Heavy Weapon" hidden="false" collective="false" import="true" type="model">
@@ -6164,7 +6166,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeea-c661-9d89-69ed" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
             <entryLink id="c5c0-cfd2-d9cd-cf4e" name="Heavy bolter" hidden="false" collective="false" import="true" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
@@ -6172,7 +6174,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="293d-7656-28f6-7ca3" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
             <entryLink id="fab6-a160-44b3-7425" name="Heavy flamer" hidden="false" collective="false" import="true" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
@@ -6180,7 +6182,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26c5-d4c3-ab6f-8a09" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
             <entryLink id="8162-900e-f644-dfdb" name="Missile launcher" hidden="false" collective="false" import="true" targetId="1469-1964-7a91-94d4" type="selectionEntry">
@@ -6188,18 +6190,18 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11ad-f19d-13e6-c9b9" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
             <entryLink id="1b19-4cae-b50c-bbe1" name="Infernus Heavy Bolter" hidden="false" collective="false" import="true" targetId="0120-6151-0960-fff1" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="15.0"/>
+                <modifier type="set" field="points" value="0.0"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5074-a76c-6dd4-6944" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -6216,7 +6218,7 @@
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name="pts" typeId="points" value="20.0"/>
+        <cost name="pts" typeId="points" value="27.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0120-6151-0960-fff1" name="Infernus Heavy Bolter" page="" hidden="false" collective="false" import="true" type="upgrade">
@@ -6345,32 +6347,6 @@
                   </infoLinks>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="7b4d-69c4-11e3-3e8c" name="Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a10b-1f33-5420-1da6">
-                      <modifiers>
-                        <modifier type="set" field="4b24-7486-0ade-544a" value="2.0">
-                          <conditionGroups>
-                            <conditionGroup type="and">
-                              <conditions>
-                                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9788-8ade-50a1-6503" type="notEqualTo"/>
-                                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a10b-1f33-5420-1da6" type="notEqualTo"/>
-                              </conditions>
-                            </conditionGroup>
-                          </conditionGroups>
-                        </modifier>
-                        <modifier type="set" field="03bd-5159-1ecb-ddf7" value="2.0">
-                          <conditionGroups>
-                            <conditionGroup type="and">
-                              <conditions>
-                                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9788-8ade-50a1-6503" type="equalTo"/>
-                                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a10b-1f33-5420-1da6" type="equalTo"/>
-                              </conditions>
-                            </conditionGroup>
-                          </conditionGroups>
-                        </modifier>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="03bd-5159-1ecb-ddf7" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4b24-7486-0ade-544a" type="max"/>
-                      </constraints>
                       <selectionEntries>
                         <selectionEntry id="a10b-1f33-5420-1da6" name="Bolt Pistol &amp; Astartes Chainsword" hidden="false" collective="false" import="true" type="upgrade">
                           <constraints>
@@ -6396,23 +6372,23 @@
                             <cost name="pts" typeId="points" value="5.0"/>
                           </costs>
                         </entryLink>
-                        <entryLink id="3164-f503-57d6-3195" name="Pistols" hidden="false" collective="false" import="true" targetId="d179-3e66-3b20-1925" type="selectionEntryGroup">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a67e-bd1a-7095-71c9" type="max"/>
-                          </constraints>
-                        </entryLink>
-                        <entryLink id="fd66-d672-b0ea-14fa" name="Melee Weapons" hidden="false" collective="false" import="true" targetId="2fa1-68ff-77fc-8e92" type="selectionEntryGroup">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7453-f201-3008-3f60" type="max"/>
-                          </constraints>
-                        </entryLink>
                         <entryLink id="a53a-556f-242c-8385" name="Heavy thunder hammer" hidden="false" collective="false" import="true" targetId="9788-8ade-50a1-6503" type="selectionEntry">
                           <constraints>
                             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6995-e452-6687-ea56" type="max"/>
                           </constraints>
                           <costs>
-                            <cost name="pts" typeId="points" value="15.0"/>
+                            <cost name="pts" typeId="points" value="12.0"/>
                           </costs>
+                        </entryLink>
+                        <entryLink id="d28c-9b28-50a8-b619" name="Pistols" hidden="false" collective="false" import="true" targetId="d179-3e66-3b20-1925" type="selectionEntryGroup">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d9dc-c617-5ad7-d566" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="7138-3b6b-9fe7-a62d" name="Melee Weapons" hidden="false" collective="false" import="true" targetId="ce40-8190-5033-a0c1" type="selectionEntryGroup">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ec5-58e2-6e06-e2e0" type="max"/>
+                          </constraints>
                         </entryLink>
                       </entryLinks>
                     </selectionEntryGroup>
@@ -6426,7 +6402,7 @@
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="pts" typeId="points" value="19.0"/>
+                    <cost name="pts" typeId="points" value="20.0"/>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
                   </costs>
@@ -6588,7 +6564,7 @@
       </categoryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>
-        <cost name="pts" typeId="points" value="10.0"/>
+        <cost name="pts" typeId="points" value="15.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -6612,7 +6588,7 @@
       </categoryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>
-        <cost name="pts" typeId="points" value="15.0"/>
+        <cost name="pts" typeId="points" value="20.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -6636,7 +6612,7 @@
       </categoryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>
-        <cost name="pts" typeId="points" value="15.0"/>
+        <cost name="pts" typeId="points" value="20.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -6660,7 +6636,7 @@
       </categoryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
-        <cost name="pts" typeId="points" value="25.0"/>
+        <cost name="pts" typeId="points" value="30.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -6684,7 +6660,7 @@
       </categoryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
-        <cost name="pts" typeId="points" value="25.0"/>
+        <cost name="pts" typeId="points" value="30.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -6708,7 +6684,7 @@
       </categoryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>
-        <cost name="pts" typeId="points" value="15.0"/>
+        <cost name="pts" typeId="points" value="20.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -6738,7 +6714,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="34.0"/>
+        <cost name="pts" typeId="points" value="20.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -6778,7 +6754,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1850-f5de-a3b7-467a" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="c5f1-ba1a-b7a3-96cd" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="d646-cf8b-0d01-69ff" type="selectionEntry">
@@ -6786,7 +6762,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7b1-8d8f-a1f4-376e" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="9c5a-c1d1-c85e-eb24" name="Inferno pistol" hidden="false" collective="false" import="true" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
@@ -6794,7 +6770,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="744c-a0c3-b432-fdeb" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="c209-923f-b00c-f45d" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
@@ -6802,7 +6778,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be79-645c-585b-5715" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="392b-506e-1050-9883" name="Astartes Chainsword" hidden="false" collective="false" import="true" targetId="c5f0-76db-2a6c-403e" type="selectionEntry">
@@ -6811,60 +6787,29 @@
           </constraints>
         </entryLink>
         <entryLink id="4f10-1616-8872-582f" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="90de-7b01-e401-888b" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="points" value="3.0">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="327d-4ca1-5b95-ca88" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d1e3-cb9b-c22b-e720" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="169e-fec1-faf2-fffe" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6102-f995-de55-64b5" type="instanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0aa4-b845-a130-20b8" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="f21f-a6f2-2727-d726" name="Power axe" hidden="false" collective="false" import="true" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="3.0"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7144-d5f7-766a-39e5" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="7138-c5e2-5cb2-0f4b" name="Power fist" hidden="false" collective="false" import="true" targetId="f122-3720-fa32-4215" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="points" value="8.0">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="327d-4ca1-5b95-ca88" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d1e3-cb9b-c22b-e720" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="169e-fec1-faf2-fffe" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6102-f995-de55-64b5" type="instanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0fd-f382-c14a-8bbd" type="max"/>
           </constraints>
-          <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-          </costs>
         </entryLink>
         <entryLink id="546c-8f3f-cdcb-d279" name="Power maul" hidden="false" collective="false" import="true" targetId="6ea7-1195-7144-438e" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="3.0"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72d1-3743-1aad-1717" type="max"/>
@@ -6872,7 +6817,7 @@
         </entryLink>
         <entryLink id="1420-10bc-1f53-98b9" name="Thunder hammer" hidden="false" collective="false" import="true" targetId="0e57-eaf5-763f-9c45" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="12.0">
+            <modifier type="set" field="points" value="10.0">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -6888,13 +6833,10 @@
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7027-aaa8-d6cc-0698" type="max"/>
           </constraints>
-          <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-          </costs>
         </entryLink>
         <entryLink id="246c-0781-d80c-9a20" name="Combat shield" hidden="false" collective="false" import="true" targetId="ae46-8351-6394-d68c" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="4.0"/>
+            <modifier type="set" field="points" value="0.0"/>
             <modifier type="decrement" field="bf65-d6fb-622e-2d06" value="1.0"/>
             <modifier type="decrement" field="bf65-d6fb-622e-2d06" value="1.0">
               <conditions>
@@ -6913,7 +6855,7 @@
         </entryLink>
         <entryLink id="4902-120c-7e63-81dd" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="3.0"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e57-1336-fbde-65bd" type="max"/>
@@ -6932,14 +6874,19 @@
                 </conditionGroup>
               </conditionGroups>
             </modifier>
+            <modifier type="set" field="points" value="0.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c77-5219-2f73-eede" type="instanceOf"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </entryLink>
         <entryLink id="53e2-bc9d-8c50-80fc" name="Storm shield" hidden="false" collective="false" import="true" targetId="38b5-ef30-f87f-5275" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="5.0"/>
+            <modifier type="set" field="points" value="0.0"/>
             <modifier type="decrement" field="e304-6093-4263-0212" value="1.0"/>
           </modifiers>
           <constraints>
@@ -6974,7 +6921,7 @@
         </entryLink>
         <entryLink id="ffd9-d86b-1d97-e912" name="Meltagun" hidden="false" collective="false" import="true" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="5.0">
+            <modifier type="set" field="points" value="0.0">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -6991,12 +6938,12 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dbf-6c71-3517-638a" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="10b7-4de0-5bc5-a623" name="Plasma gun" hidden="false" collective="false" import="true" targetId="8c14-22cc-93ce-b85a" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="5.0">
+            <modifier type="set" field="points" value="0.0">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -7013,13 +6960,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c99c-1729-2c33-7b23" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="a03d-52a2-7ab3-74c9" name="Storm bolter" hidden="false" collective="false" import="true" targetId="2b03-8d64-3711-f300" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="5.0"/>
-            <modifier type="set" field="points" value="3.0">
+            <modifier type="set" field="points" value="0.0"/>
+            <modifier type="set" field="points" value="0.0">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -7038,7 +6985,7 @@
         </entryLink>
         <entryLink id="74e4-14ac-73b4-20f5" name="Grav-gun" hidden="false" collective="false" import="true" targetId="538c-b8cd-b452-2685" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="5.0">
+            <modifier type="set" field="points" value="0.0">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -7055,12 +7002,12 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e407-e4ec-c79d-149a" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="c506-5547-21ce-42f3" name="Deathwatch Combi-flamer" hidden="false" collective="false" import="true" targetId="2017-2709-a4ed-77bf" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="5.0">
+            <modifier type="set" field="points" value="0.0">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -7079,7 +7026,7 @@
         </entryLink>
         <entryLink id="e533-8178-f680-e725" name="Deathwatch combi-grav" hidden="false" collective="false" import="true" targetId="c94b-3c50-8214-c7cc" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="10.0">
+            <modifier type="set" field="points" value="0.0">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -7098,7 +7045,7 @@
         </entryLink>
         <entryLink id="1b9a-ce3a-583f-7795" name="Deathwatch Combi-melta" hidden="false" collective="false" import="true" targetId="2f4f-a8b2-8b30-3841" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="10.0">
+            <modifier type="set" field="points" value="0.0">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -7117,7 +7064,7 @@
         </entryLink>
         <entryLink id="406d-9c3d-e36f-1296" name="Deathwatch combi-plasma" hidden="false" collective="false" import="true" targetId="7006-cb24-2df9-fce0" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="10.0">
+            <modifier type="set" field="points" value="0.0">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -7139,7 +7086,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f37-d146-f04d-6320" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
       </entryLinks>
@@ -7160,7 +7107,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e38-e0b5-33a0-6b91" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -7174,17 +7121,17 @@
       <entryLinks>
         <entryLink id="0246-0e81-62b3-60a9" name="Heavy flamer" hidden="false" collective="false" import="true" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="946f-87d4-13f6-6aba" name="Assault cannon" hidden="false" collective="false" import="true" targetId="51b0-3d46-5af4-683e" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="c5a9-bec0-f008-193e" name="Plasma cannon" hidden="false" collective="false" import="true" targetId="eb15-db61-5d4f-b65e" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="2bb0-798e-62a7-0cb7" name="Cyclone missile launcher" hidden="false" collective="false" import="true" targetId="25b3-79f7-73cd-9321" type="selectionEntry">
@@ -7192,7 +7139,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9d6-d2cc-ec08-0361" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="20.0"/>
+            <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </entryLink>
       </entryLinks>
@@ -7210,7 +7157,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7991-19b5-6514-37fa" type="min"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
             <entryLink id="6e07-c98f-54d5-dd62" name="Storm bolter" hidden="false" collective="false" import="true" targetId="2b03-8d64-3711-f300" type="selectionEntry">
@@ -7234,7 +7181,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="801c-d1af-0479-ded1" type="min"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
             <entryLink id="1496-6824-5a80-6f2e" name="Storm bolter" hidden="false" collective="false" import="true" targetId="2b03-8d64-3711-f300" type="selectionEntry">
@@ -7261,7 +7208,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7cf-d86e-a8b7-a9e6" type="min"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="3.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
             <entryLink id="6e42-4335-405a-a56f" name="Storm bolter" hidden="false" collective="false" import="true" targetId="2b03-8d64-3711-f300" type="selectionEntry">
@@ -7288,7 +7235,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="139c-4a8d-4218-47c8" type="min"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="3.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
             <entryLink id="e8ab-1044-44f2-4ec3" name="Storm bolter" hidden="false" collective="false" import="true" targetId="2b03-8d64-3711-f300" type="selectionEntry">
@@ -7315,7 +7262,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4212-0be5-be5e-2930" type="min"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="3.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
             <entryLink id="7314-6a7d-519e-f202" name="Storm bolter" hidden="false" collective="false" import="true" targetId="2b03-8d64-3711-f300" type="selectionEntry">
@@ -7335,7 +7282,7 @@
           <entryLinks>
             <entryLink id="0c5f-9137-0913-f2e4" name="Thunder hammer" hidden="false" collective="false" import="true" targetId="f1cb-bfc4-0b93-1203" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="10.0"/>
+                <modifier type="set" field="points" value="0.0"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc92-888f-19ff-a491" type="max"/>
@@ -7399,7 +7346,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be80-de73-6a1c-ff28" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -7413,12 +7360,12 @@
       <entryLinks>
         <entryLink id="6e44-b572-78d6-7c49" name="Power fist" hidden="false" collective="false" import="true" targetId="f122-3720-fa32-4215" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="a81d-b497-816f-bdaf" name="Chainfist" hidden="false" collective="false" import="true" targetId="e464-77c1-12bb-e52f" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="609d-02f0-fc30-9bf2" name="Lightning Claw (Pair)" hidden="false" collective="false" import="true" targetId="b050-572b-911b-d51c" type="selectionEntry">
@@ -7491,7 +7438,7 @@
         </entryLink>
         <entryLink id="af9d-9fe5-063a-59d2" name="Stalker-pattern boltgun" hidden="false" collective="false" import="true" targetId="fcfd-2bdb-cb53-7dc8" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="3.0">
+            <modifier type="set" field="points" value="0.0">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
@@ -7507,7 +7454,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67b1-4373-8165-a9ff" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </entryLink>
         <entryLink id="d1bf-3d81-73ed-87c7" name="Deathwatch Equipment List" hidden="false" collective="false" import="true" targetId="44e0-64a6-bc26-1b19" type="selectionEntryGroup">
@@ -7760,38 +7707,41 @@
         <entryLink id="cc0e-d0d2-6093-e99a" name="Litany of Hate" hidden="false" collective="false" import="true" targetId="a441-cc96-406f-0667" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="2fa1-68ff-77fc-8e92" name="Melee Weapons" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="9239-1e5d-568d-cd4f" name="Melee Weapons" hidden="false" collective="false" import="true">
       <entryLinks>
         <entryLink id="85ce-50b9-cff5-745b" name="Astartes Chainsword" hidden="false" collective="false" import="true" targetId="c5f0-76db-2a6c-403e" type="selectionEntry"/>
         <entryLink id="c350-5c03-9506-c030" name="Power axe" hidden="false" collective="false" import="true" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="3.0"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
         </entryLink>
         <entryLink id="3fb9-61af-22e0-4c76" name="Power fist" hidden="false" collective="false" import="true" targetId="caae-f721-310b-3798" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="8.0"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
         </entryLink>
         <entryLink id="f059-4bc1-c645-d60a" name="Power maul" hidden="false" collective="false" import="true" targetId="6ea7-1195-7144-438e" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="3.0"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
         </entryLink>
         <entryLink id="9122-ac67-9039-922f" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="3.0"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
         </entryLink>
         <entryLink id="5a5d-3b98-2bee-8d65" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="571f-9ce0-488c-0857" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="3.0"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
         </entryLink>
         <entryLink id="5fd7-2110-69a8-b986" name="Thunder hammer" hidden="false" collective="false" import="true" targetId="f1cb-bfc4-0b93-1203" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="12.0"/>
+            <modifier type="set" field="points" value="10.0"/>
           </modifiers>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
@@ -7800,7 +7750,7 @@
         <entryLink id="b6b7-b5c1-1e4e-0c5f" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry"/>
         <entryLink id="d78c-4b27-7c3b-cfd5" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="5.0"/>
+            <modifier type="set" field="points" value="0.0"/>
             <modifier type="set" field="points" value="0.0">
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a0b8-6a5c-ea09-44f9" type="instanceOf"/>
@@ -7810,15 +7760,22 @@
         </entryLink>
         <entryLink id="4490-7c45-219d-7f38" name="Grav-pistol" hidden="false" collective="false" import="true" targetId="7b66-cac7-e582-a518" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="5.0"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
         </entryLink>
         <entryLink id="d4f9-cdcb-31bf-c458" name="Inferno pistol" hidden="false" collective="false" import="true" targetId="83f0-56d1-b852-f21c" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="5.0"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
         </entryLink>
-        <entryLink id="527c-a1ba-4116-0feb" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="d646-cf8b-0d01-69ff" type="selectionEntry"/>
+        <entryLink id="527c-a1ba-4116-0feb" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="d646-cf8b-0d01-69ff" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="f823-a5a7-2b6e-e168" name="Chapter Relics" hidden="false" collective="false" import="true">


### PR DESCRIPTION
I have completed the list from the Deathwatch data.  I realize you all aren't looking for new data developers right now, but I had already done the work so I figured I would update you all here and put in a PR that you can take or leave.  I used the Data Editor and attempted to follow all of the data paradigms within it.

- [x] Chaplain Cassius currently costs 95 pts, but should cost 85 pts
- [x] Codicier Natorian currently costs 100 pts, but should cost 90 pts
- [x] Watch Captain Artemis currently costs 105 pts, but should cost 95 pts
- [x] Watch Master currently costs 130 pts, but should cost 115 pts
- [x] Deathwatch Veterans currently cost 20 pts per model, but should cost 27 pts per model
- [x] Deathwatch Veterans > Deathwatch Veteran w/ Heavy Thunder Hammer’s heavy thunder hammer currently costs 15 pts, but should cost 12 pts
- [x] Deathwatch Veterans > Watch Sergeant’s xenophase blade currently costs 10 pts, but should cost 5 pts
- [x] Deathwatch Veterans > Watch Sergeant’s combat shield currently costs 4 pts, but should cost 0 pts
- [x] Deathwatch Veterans’ stalker-pattern boltgun currently costs 3 pts, but should cost 0 pts
 Grav-pistol currently costs 5 pts, but should cost 0 pts for:
- [x] Deathwatch Veterans
- [x] Veteran Bike Squad > Veteran Biker Sergeant
 Hand flamer currently costs 5 pts, but should cost 0 pts for:
- [x] Deathwatch Veterans
- [x] Veteran Bike Squad > Veteran Biker Sergeant
 Inferno pistol currently costs 5 pts, but should cost 0 pts for:
- [x] Deathwatch Veterans
- [x] Veteran Bike Squad > Veteran Biker Sergeant
- [x] Deathwatch Veterans’ lightning claw currently costs 3 pts, but should cost 0 pts
 Plasma pistol currently costs 5 pts, but should cost 0 pts for:
- [x] Deathwatch Veterans
- [x] Veteran Bike Squad > Veteran Biker Sergeant
- [x] Deathwatch Veterans’ power axe currently costs 3 pts, but should cost 0 pts
- [x] Deathwatch Veterans’ power fist currently costs 8 pts, but should cost 0 pts
- [x] Deathwatch Veterans’ power maul currently costs 3 pts, but should cost 0 pts
- [x] Deathwatch Veterans’ power sword currently costs 3 pts, but should cost 0 pts
 Storm shield currently costs 5 pts, but should cost 0 pts for:
- [x] Deathwatch Veterans
- [x] Veteran Bike Squad > Veteran Biker Sergeant
- [x] Deathwatch Veterans’ Deathwatch combi-flamer currently costs 5 pts, but should cost 0 pts
- [x] Deathwatch Veterans’ Deathwatch combi-grav currently costs 10 pts, but should cost 0 pts
- [x] Deathwatch Veterans’ Deathwatch combi-melta currently costs 10 pts, but should cost 0 pts
- [x] Deathwatch Veterans’ Deathwatch combi-plasma currently costs 10 pts, but should cost 0 pts
 Flamer currently costs 5 pts, but should cost 0 pts for:
- [x] Deathwatch Veterans
- [x] Veteran Bike Squad > Veteran Biker Sergeant
- [x] Deathwatch Veterans’ grav-gun currently costs 5 pts, but should cost 0 pts
- [x] Deathwatch Veterans’ meltagun currently costs 5 pts, but should cost 0 pts
- [x] Deathwatch Veterans’ plasma gun currently costs 5 pts, but should cost 0 pts
 Storm bolter currently costs 5 pts, but should cost 0 pts for:
- [x] Deathwatch Veterans
- [x] Veteran Bike Squad > Veteran Biker Sergeant
- [x] Kill Team Cassius currently costs 240 pts, but should cost 220 pts
- [x] Deathwatch Terminator Squad currently cost 33 pts per model, but should cost 35 pts per model
- [x] Deathwatch Terminator Squad’s power fist currently costs 5 pts, but should cost 0 pts
- [x] Deathwatch Terminator Squad’s chainfist currently costs 5 pts, but should cost 0 pts
 Thunder hammer currently costs 10 pts, but should cost 0 pts for:
- [x] Deathwatch Terminator Squad
- [x] Veteran Bike Squad > Veteran Biker Sergeant
- [x] Deathwatch Terminator Squad’s teleport homer currently costs 5 pts, but should cost 0 pts
- [x] Deathwatch Terminator Squad’s assault cannon currently costs 15 pts, but should cost 0 pts
- [x] Deathwatch Terminator Squad’s cyclone missile launcher currently costs 20 pts, but should cost 10 pts
- [x] Deathwatch Terminator Squad’s heavy flamer currently costs 10 pts, but should cost 0 pts
- [x] Deathwatch Terminator Squad’s plasma cannon currently costs 15 pts, but should cost 0 pts
- [x] Veteran Bike Squad currently cost 30 pts per model, but should cost 35 pts per model
- [x] Veteran Bike Squad > Veteran Attack Bike’s heavy bolter currently costs 20 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Attack Bike’s multi-melta currently costs 30 pts, but should cost 0 pts
- [x] Veteran Bike Squad’s power axe currently costs 3 pts, but should cost 0 pts
- [x] Veteran Bike Squad’s power maul currently costs 3 pts, but should cost 0 pts
- [x] Veteran Bike Squad’s power sword currently costs 3 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s Deathwatch shotgun currently costs 5 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s stalker-pattern boltgun currently costs 5 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s lightning claw currently costs 5 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s power fist currently costs 10 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s xenophase blade currently costs 10 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s Deathwatch boltgun currently costs 5 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s Deathwatch combi-flamer currently costs 10 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s Deathwatch combi-grav currently costs 15 pts, but should cost 0 pts
- [x] Veran Bike Squad > Veteran Biker Sergeant’s Deathwatch combi-melta currently costs 15 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s Deathwatch combi-plasma currently costs 15 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s grav-gun currently costs 10 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s meltagun currently costs 10 pts, but should cost 0 pts
- [x] Veteran Bike Squad > Veteran Biker Sergeant’s plasma gun currently costs 10 pts, but should cost 0 pts
- [x] Corvus Blackstar currently costs 165 pts, but should cost 150 pts
- [x] Corvus Blackstar’s hurricane bolter currently costs 15 pts, but should cost 0 pts
- [x] Corvus Blackstar’s auspex array currently costs 5 pts, but should cost 0 pts
- [x] Corvus Blackstar’s infernum halo-launcher currently costs 10 pts, but should cost 0 pts
- [x] Aquila Kill Team Specialism currently costs 10 pts, but should cost 15 pts
- [x] Dominatus Kill Team Specialism currently costs 15 pts, but should cost 20 pts
- [x] Furor Kill Team Specialism currently costs 25 pts, but should cost 30 pts
- [x] Malleus Kill Team Specialism currently costs 25 pts, but should cost 30 pts
- [x] Purgatus Kill Team Specialism currently costs 15 pts, but should cost 20 pts
- [x] Venator Kill Team Specialism currently costs 15 pts, but should cost 20 pts